### PR TITLE
Fix dhcpcd missing config file

### DIFF
--- a/roles/network_eth0/tasks/main.yml
+++ b/roles/network_eth0/tasks/main.yml
@@ -1,7 +1,14 @@
+- name: Install dhcpcd
+  become: true
+  apt:
+    name: dhcpcd5
+    state: present
+
 - name: Configure static IP for eth0
   become: true
   blockinfile:
     path: /etc/dhcpcd.conf
+    create: yes
     marker: "# {mark} ANSIBLE eth0 config"
     block: |
       interface eth0


### PR DESCRIPTION
## Summary
- install `dhcpcd` and create the config file

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_686beb5a7ff88331b7e4e06968af5178