### PR TITLE
Use systemd-networkd on eth0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains an Ansible playbook to configure a Raspberry Pi 2 Model
 
 ## Features
 
-- Static IP configuration for the printer network
+- Static IP configuration for the printer network via systemd-networkd
 - Minimal DHCP service using dnsmasq
 - CUPS setup with a shared queue
 - Samba sharing for Windows clients

--- a/roles/dhcp_server/templates/dnsmasq.conf.j2
+++ b/roles/dhcp_server/templates/dnsmasq.conf.j2
@@ -1,4 +1,3 @@
 interface=eth0
 bind-interfaces
 dhcp-range=192.168.3.2,192.168.3.2,255.255.255.252,24h
-dhcp-host=92:07:62:c1:57:fa,192.168.3.2

--- a/roles/network_eth0/handlers/main.yml
+++ b/roles/network_eth0/handlers/main.yml
@@ -1,5 +1,5 @@
-- name: Restart dhcpcd
+- name: Restart systemd-networkd
   become: true
   service:
-    name: dhcpcd
+    name: systemd-networkd
     state: restarted

--- a/roles/network_eth0/tasks/main.yml
+++ b/roles/network_eth0/tasks/main.yml
@@ -1,25 +1,15 @@
-- name: Install dhcpcd
+- name: Deploy static IP configuration for eth0
   become: true
-  apt:
-    name: dhcpcd5
-    state: present
+  template:
+    src: eth0.network.j2
+    dest: /etc/systemd/network/eth0.network
+    mode: '0644'
+  notify: Restart systemd-networkd
 
-- name: Configure static IP for eth0
-  become: true
-  blockinfile:
-    path: /etc/dhcpcd.conf
-    create: yes
-    marker: "# {mark} ANSIBLE eth0 config"
-    block: |
-      interface eth0
-      static ip_address=192.168.3.1/30
-      nohook wpa_supplicant
-  notify: Restart dhcpcd
-
-- name: Ensure dhcpcd service is enabled
+- name: Ensure systemd-networkd service is enabled
   become: true
   service:
-    name: dhcpcd
+    name: systemd-networkd
     enabled: true
     state: started
 

--- a/roles/network_eth0/templates/eth0.network.j2
+++ b/roles/network_eth0/templates/eth0.network.j2
@@ -1,0 +1,5 @@
+[Match]
+Name=eth0
+
+[Network]
+Address=192.168.3.1/30


### PR DESCRIPTION
## Summary
- use systemd-networkd instead of dhcpcd to set Pi's static IP
- relax dnsmasq configuration so it no longer pins the printer MAC
- document new static IP method

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_686bfe236a3c8331b125655b2497f9a2