### PR TITLE
Switch to USB printer with brlaser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # rpi-print-server
 
-This repository contains an Ansible playbook to configure a Raspberry Pi 2 Model B as a print server for a Brother HL3170CDW printer. The Pi uses Wi-Fi (`wlan0`) to receive print jobs from the LAN and connects to the printer over an isolated Ethernet network (`eth0`).
+This repository contains an Ansible playbook to configure a Raspberry Pi 2 Model B as a print server for a Brother HL3170CDW printer. The Pi receives print jobs over the network and connects to the printer via USB.
 
 ## Features
 
-- Static IP configuration for the printer network via systemd-networkd
-- Minimal DHCP service using dnsmasq
-- CUPS setup with a shared queue
+- CUPS setup with a shared queue for a USB-connected printer
+- Printer drivers installed automatically (brlaser with Gutenprint fallback)
 - Samba sharing for Windows clients
 - AirPrint advertisement via Avahi
-- Optional firewall rules to prevent forwarding between `wlan0` and `eth0`
 
 ## Usage
 
@@ -26,5 +24,3 @@ Download the packaged installer from the latest release and run it directly on t
 ```bash
 curl -L https://github.com/ke4roh/rpi-print-server/releases/download/r1.1/printserver-install-1.1.run | bash
 ```
-
-The roles assume the printer will be reachable at `192.168.3.2` on the private subnet.

--- a/roles/cups_setup/tasks/main.yml
+++ b/roles/cups_setup/tasks/main.yml
@@ -1,9 +1,11 @@
-- name: Install CUPS packages
+- name: Install CUPS packages and drivers
   become: true
   apt:
     name:
       - cups
       - cups-bsd
+      - printer-driver-brlaser
+      - printer-driver-gutenprint
     state: present
 
 - name: Ensure CUPS service is enabled
@@ -13,10 +15,24 @@
     enabled: true
     state: started
 
-- name: Add printer queue
+- name: Detect USB printer URI
+  become: true
+  command: lpinfo -v
+  register: lpinfo_output
+
+- name: Set USB printer URI
+  set_fact:
+    printer_usb_uri: "{{ lpinfo_output.stdout_lines | select('match', '^direct usb://') | list | first | regex_replace('^direct ', '') }}"
+
+- name: Add USB printer queue
   become: true
   command: >-
-    lpadmin -p HL3170CDW -E -v socket://192.168.3.2 -m everywhere
+    lpadmin -p HL3170CDW -E -v {{ printer_usb_uri }} -m drv:///brlaser.drv/brlaser.ppd
   args:
     creates: /etc/cups/ppd/HL3170CDW.ppd
+  notify: Restart cups
+
+- name: Enable printer sharing
+  become: true
+  command: cupsctl --share-printers
   notify: Restart cups

--- a/site.yml
+++ b/site.yml
@@ -2,9 +2,6 @@
 - hosts: printserver
   become: true
   roles:
-    - network_eth0
-    - dhcp_server
     - cups_setup
     - samba_share
     - airprint
-    - firewall_isolate


### PR DESCRIPTION
## Summary
- install brlaser and Gutenprint drivers with CUPS
- auto-detect USB printer and register queue
- share printers via cupsctl
- simplify playbook for USB connection
- document USB setup

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_686c6972ab6c8331899e418418b07f9b